### PR TITLE
Create separate backend and frontend readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Overview
 FarmLink is a full-stack web application designed to help smallholder farmers in Kenya manage their crops and farm tasks efficiently. It provides a user-friendly dashboard, crop and task management, and insightful analytics to improve farm productivity.
 
-- **Frontend:** React, React Router, Chart.js, Tailwind CSS
-- **Backend:** Node.js, Express, MongoDB, JWT authentication
+- **Frontend:** React, React Router, Chart.js, Tailwind CSS ([see frontend/README.md](frontend/README.md))
+- **Backend:** Node.js, Express, MongoDB, JWT authentication ([see backend/README.md](backend/README.md))
 
 ---
 
@@ -28,21 +28,10 @@ FarmLink is a full-stack web application designed to help smallholder farmers in
 ### Installation
 
 #### Backend
-```bash
-cd backend
-npm install
-cp .env.example .env # Set your MONGO_URI and JWT_SECRET
-npm run dev # or npm start
-```
+See [backend/README.md](backend/README.md) for backend setup and details.
 
 #### Frontend
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-The frontend will run on [http://localhost:5173](http://localhost:5173) by default.
+See [frontend/README.md](frontend/README.md) for frontend setup and details.
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,58 @@
+# FarmLink Backend
+
+This is the backend for FarmLink: Smallholder Crop Manager. It provides a RESTful API for user authentication, crop management, and task tracking.
+
+---
+
+## Tech Stack
+- Node.js
+- Express
+- MongoDB (Mongoose)
+- JWT authentication
+- CORS
+
+---
+
+## Getting Started
+
+### Prerequisites
+- Node.js (v16+ recommended)
+- npm or yarn
+- MongoDB (local or cloud)
+
+### Installation
+```bash
+cd backend
+npm install
+cp .env.example .env # Set your MONGO_URI and JWT_SECRET
+npm run dev # or npm start
+```
+
+---
+
+## Project Structure
+- `server.js`: Main entry, Express app, middleware, error handling, route mounting
+- `routes/`: API endpoints (`auth.js`, `crops.js`, `tasks.js`)
+- `models/`: Mongoose schemas (`User.js`, `Crop.js`, `Task.js`)
+- `middleware/`: Auth middleware (`auth.js`)
+- `seed.js`: Seed data script
+
+---
+
+## API Reference
+See [../API.md](../API.md) for all endpoints, request/response formats, and examples.
+
+---
+
+## Usage Guide
+See [../USEGUIDE.md](../USEGUIDE.md) for step-by-step instructions.
+
+---
+
+## Architecture
+See [../ARCHITECTURE.md](../ARCHITECTURE.md) for system design and data flow.
+
+---
+
+## License
+MIT

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,68 @@
+# FarmLink Frontend
+
+This is the frontend for FarmLink: Smallholder Crop Manager. It is a React SPA for farmers to manage crops and tasks, visualize data, and interact with the backend API.
+
+---
+
+## Tech Stack
+- React
+- React Router
+- Chart.js & react-chartjs-2
+- Tailwind CSS
+- Axios
+- Vite
+
+---
+
+## Getting Started
+
+### Prerequisites
+- Node.js (v16+ recommended)
+- npm or yarn
+
+### Installation
+```bash
+cd frontend
+npm install
+npm run dev
+```
+The app runs on [http://localhost:5173](http://localhost:5173) by default.
+
+---
+
+## Project Structure
+- `src/`
+  - `App.jsx`: Main entry, routing, context providers
+  - `components/`: UI components (Navbar, Dashboard, CropList, CropForm, TaskList, TaskForm, Profile, Auth forms, etc.)
+  - `context/`: AuthContext for authentication state and methods
+  - `main.jsx`: App bootstrap
+  - `index.css`: Global styles (Tailwind)
+- `index.html`: HTML entry point
+
+---
+
+## Main Components
+- **Navbar**: Navigation bar with user info and links
+- **Dashboard**: Crop/task stats and charts
+- **CropList**: List, filter, and manage crops
+- **CropForm**: Add/edit crop details
+- **TaskList**: List, filter, and manage tasks
+- **TaskForm**: Add/edit farm tasks
+- **Profile**: View and update user profile
+- **Register/Login**: User authentication forms
+- **AuthContext**: Provides authentication state and methods
+
+---
+
+## Usage Guide
+See [../USEGUIDE.md](../USEGUIDE.md) for step-by-step instructions.
+
+---
+
+## Architecture
+See [../ARCHITECTURE.md](../ARCHITECTURE.md) for system design and data flow.
+
+---
+
+## License
+MIT


### PR DESCRIPTION
Add separate README files for backend and frontend to improve documentation organization and clarity.